### PR TITLE
fix: stop Detroit "Electric Cars" from requiring gas

### DIFF
--- a/assets/Script/CoreGame/PolicyDefinitions.ts
+++ b/assets/Script/CoreGame/PolicyDefinitions.ts
@@ -330,6 +330,7 @@ export class Policy {
             BLD.CarFactory.staticInput.Bat =
                 (BLD.CarFactory.staticInput.Petrol ?? BLD.CarFactory.staticInput.Gas) * 0.5;
             delete BLD.CarFactory.staticInput.Petrol;
+            delete BLD.CarFactory.staticInput.Gas;
         },
     };
     FreeTransportToTradeCenter: IPolicy = {


### PR DESCRIPTION
When in Detroit, the free "Nikola Tesla" policy only adds a requirement for batteries. The policy specifically removes petrol from the requirements, meaning electrifying car production only adds requirements without a compensating benefit. This PR changes it to remove *both* petrol and gas from the policy.