### PR TITLE
Bugfix: Wind Turbines and Solar Panels stuck Shutdown / Offline

### DIFF
--- a/assets/Script/CoreGame/World.ts
+++ b/assets/Script/CoreGame/World.ts
@@ -20,7 +20,7 @@ import EntityVisual from "./EntityVisual";
 import { gridEqual, gridToPosition, gridToString, stringToGrid, stringToPosition } from "./GridHelper";
 import { ConstructionStatus, Entity, makeEntity } from "./Logic/Entity";
 import { findByType } from "./Logic/Find";
-import { addResourceTo, BLD, canBuild, Deposit, getBuilderMoveSpeed, isMine, MAP, RES } from "./Logic/Logic";
+import { addResourceTo, BLD, buildingCanInput, canBuild, Deposit, getBuilderMoveSpeed, isMine, MAP, RES } from "./Logic/Logic";
 import { depositsToArray, IMap } from "./MapDefinitions";
 import BulletsPool from "./NodePools/BulletsPool";
 import DotsPool from "./NodePools/DotsPool";
@@ -424,9 +424,9 @@ export default class World extends cc.Component {
         }
         const entity = makeEntity(xy, building);
         Object.assign(entity, D.entityDefault);
-        if (entity.type === "WindTurbine" || entity.type === "SolarPanel") {
+        if (!buildingCanInput(entity) && BLD[entity.type].power >= 0) {
             entity.turnOff = false;
-        }        
+        }
         entity.construction = status;
         D.buildingsToConstruct[xy] = entity;
         this.placeBuilding(entity);

--- a/assets/Script/CoreGame/World.ts
+++ b/assets/Script/CoreGame/World.ts
@@ -424,6 +424,9 @@ export default class World extends cc.Component {
         }
         const entity = makeEntity(xy, building);
         Object.assign(entity, D.entityDefault);
+        if (entity.type === "WindTurbine" || entity.type === "SolarPanel") {
+            entity.turnOff = false;
+        }        
         entity.construction = status;
         D.buildingsToConstruct[xy] = entity;
         this.placeBuilding(entity);


### PR DESCRIPTION
**Bug:** When the Shutdown setting is enabled as the default for buildings this causes all future constructed Wind and Solar buildings to be Shutdown without the panel option to turn back on.

**Fix:** A check is made prior to placing a building; if the entity is a Wind Turbine or Solar Panel then the Shutdown setting is set to off.

**Result:** Wind and Solar buildings cannot be Shutdown when enabling the setting as the default. If either is constructed while Shutdown is enabled as default then both will function as normal whereas all other buildings will continue to be built Shutdown / offline.