### PR TITLE
Bugfix: Fix reset not being saved on color theme editor

### DIFF
--- a/assets/Script/UI/ColorThemeEditorPage.ts
+++ b/assets/Script/UI/ColorThemeEditorPage.ts
@@ -69,6 +69,11 @@ export function ColorThemeEditorPage() {
                                                 delete D.persisted.colorThemeOverrides[k];
                                             }
                                         });
+                                        forEach(D.persisted.colorThemeOverrides, (k, v) => {
+                                            if (!(k in overrides)) {
+                                                delete D.persisted.colorThemeOverrides[k];
+                                            }
+                                        });
                                         await saveData();
                                         reloadGame();
                                     },


### PR DESCRIPTION
If you reset a color, this then deletes it from overrides.
When you press save this loops through overrides and assigns the color to persisted data or deletes it, but since the color is not in overrides it never gets deleted.