### PR TITLE
Change power bank units to Joules

### DIFF
--- a/assets/Script/CoreGame/PowerBankPanel.ts
+++ b/assets/Script/CoreGame/PowerBankPanel.ts
@@ -19,7 +19,7 @@ export function PowerBankPanel(): m.Component<{ entity: Entity }> {
                 m(".box", [
                     m(".two-col", [
                         m("div", m("div", t("PowerBankChargeSpeed"))),
-                        m("div", t("PerSecond", { time: nf(chargeSpeed) + "W" })),
+                        m("div", `${nf(chargeSpeed)}W`),
                     ]),
                     m(".hr.dashed"),
                     m(

--- a/assets/Script/CoreGame/PowerBankPanel.ts
+++ b/assets/Script/CoreGame/PowerBankPanel.ts
@@ -33,7 +33,7 @@ export function PowerBankPanel(): m.Component<{ entity: Entity }> {
                     m(".sep5"),
                     m(".two-col.text-m.text-desc", [
                         m("div", t("PowerBankPowerLeft")),
-                        m("div", `${nf(entity.powerLeft)}W/${nf(total)}W (${formatPercent(entity.powerLeft / total)})`),
+                        m("div", `${nf(entity.powerLeft)}J/${nf(total)}J (${formatPercent(entity.powerLeft / total)})`),
                     ]),
                 ]),
             ];

--- a/assets/Script/UI/StatPage.ts
+++ b/assets/Script/UI/StatPage.ts
@@ -97,7 +97,7 @@ export function StatPage(): m.Comp<{ entity: Entity; docked: boolean }> {
                                 m(".text-s.text-desc", t("PowerRequired")),
                             ]),
                             m(".f1", [
-                                m("div", `${nf(getPowerBankLeft(), true)}W`),
+                                m("div", `${nf(getPowerBankLeft(), true)}J`),
                                 m(".text-s.text-desc", t("PowerBankLeft")),
                             ]),
                         ]),


### PR DESCRIPTION
The correct unit for energy is joules, where one watt is a joule per second. Therefore, the amount of power stored in the power bank should be in joules, while power input/output/balance for the current tick should still be in watts.