### PR TITLE
[QoL /  New Player Experience] Clarify InspectPage's BuildingProfit Estimates Source

### DIFF
--- a/assets/Script/UI/InspectPage.ts
+++ b/assets/Script/UI/InspectPage.ts
@@ -366,7 +366,7 @@ export function InspectPage(): m.Comp<{ xy: string }> {
                                 },
                                 [
                                     m(".f1", [
-                                        m("div", t("BuildingProfit")),
+                                        m("div", t("BuildingProfit")+" ("+t("AutoSell")+")"),
                                         m(
                                             ".text-s.blue",
                                             showProfitBreakdown ? t("HideBreakdown") : t("ShowBreakdown")


### PR DESCRIPTION
### Overview
Updated the label 'Profit' element on InspectPage for buildings so that it is now labelled 'Profit (Auto Sell)'. This change was made to better make clear that the calculation is based on local market prices not the player market. 

[Profit Element of InspectPage](https://i.gyazo.com/74fdd9f1db2fe6f099e7d5a6796470a5.png)

**Additional Note:**
Thanks to existing localization entries; this modification was accomplished via the following operations `t("BuildingProfit")+" ("+t("AutoSell")+")` As a result no localization updates are required.