### PR TITLE
[Accessibility \ QoL] Adds a hint indicator to Show Positive Modifiers toggle element 

### DIFF
--- a/assets/Script/UI/BuildPage.ts
+++ b/assets/Script/UI/BuildPage.ts
@@ -167,11 +167,10 @@ export function BuildPage(): m.Comp<{ xy: string }> {
                         ),
                         m(".hr"),
                         uiBoxToggleContent(
-                            m(
-                                ".text-s.uppercase",
-                                { title: t("OnlyShowPositiveModifiersHint") },
-                                t("OnlyShowPositiveModifiers")
-                            ),
+                            m("div.two-col", [
+                                m("div.blue.text-m.pointer", { style: "margin-right: 4px;", title: t("OnlyShowPositiveModifiersHint") }, "💡"),
+                                m(".text-s.uppercase", t("OnlyShowPositiveModifiers"))
+                            ]),
                             onlyShowPositiveTiles,
                             () => {
                                 onlyShowPositiveTiles = !onlyShowPositiveTiles;

--- a/assets/Script/UI/BuildPage.ts
+++ b/assets/Script/UI/BuildPage.ts
@@ -168,7 +168,7 @@ export function BuildPage(): m.Comp<{ xy: string }> {
                         m(".hr"),
                         uiBoxToggleContent(
                             m("div.two-col", [
-                                m("div.blue.text-m.pointer", { style: "margin-right: 4px;", title: t("OnlyShowPositiveModifiersHint") }, "💡"),
+                                m("div.blue.text-m.cursor-help", { style: "margin-right: 4px;", title: t("OnlyShowPositiveModifiersHint") }, "💡"),
                                 m(".text-s.uppercase", t("OnlyShowPositiveModifiers"))
                             ]),
                             onlyShowPositiveTiles,


### PR DESCRIPTION
### Overview
Adds a bulb emoticon to better indicate that a relevant hint / tooltip exists.  _(Originally suggested by @BarkyAllen via Official Discord #suggestions channel. )_

[Tooltip Indicator: Only Show Positive Modifiers [type: gif]](https://i.gyazo.com/58e739a6bf3d10acaa6f6f9884f06541.gif)
