### PR TITLE
[QoL] HQ Panel - (UI Element) Hide/Show Categories 

### DIFF
--- a/assets/Script/UI/HeadquarterPage.ts
+++ b/assets/Script/UI/HeadquarterPage.ts
@@ -37,6 +37,9 @@ import { routeTo, showAlert, showLoader, showToast } from "./UISystem";
 import { UserVerification } from "./UserVerification";
 
 const NAME_CHANGE_COOLDOWN_HOUR = 24;
+let minimizeHighlightAll: boolean = false;
+let minimizeBuildingPermit: boolean = false;
+let minimizeExpansionPacks: boolean = false;
 
 export function startWebLogin() {
     const popup = window.open(`${API_HOST}/steam`, "_blank", "popup");
@@ -52,10 +55,6 @@ export function startWebLogin() {
 export function HeadquarterPage(): m.Comp {
     let editingName = false;
     let newName: string;
-    let minimizeStreaming = false;
-    let minimizeHighlightAll = false;
-    let minimizeBuildingPermit = false;
-    let minimizeExpansionPacks = false;
     return {
         oninit: () => {
             newName = D.persisted.userName;

--- a/assets/Script/UI/StreamingPage.ts
+++ b/assets/Script/UI/StreamingPage.ts
@@ -47,9 +47,9 @@ export const Streaming: IStreamingConfig = {
 };
 
 let mediaRecorder: MediaRecorder;
+let minimizeStreaming: boolean = false;
 
 export function StreamingPage(): m.Comp {
-    let minimizeStreaming: boolean = false;
     return {
         view: (vnode) => {
             if (isIOS() || isAndroid()) {


### PR DESCRIPTION
### Overview
Adds 4 Hide/Show UI Elements to the HQ Panel. A Hide/Show element is added for each of the following categories: Streaming Settings, Highlight Buildings, Building Permits* and Expansion Packs. The state of the UI elements will be remembered / stored for the duration of the session. (Until game is reloaded)

[HQ Panel [type: gif]](https://i.gyazo.com/e482ce1655fb0060e06ec3133a3a0831.gif)

### Notes
1. Updated `Script\UI\HeadquarterPage.ts` and `StreamingPage.ts`;  
Modified title elements for each of the existing panels categories and inserted the Hide/Show elements and logic. 
*In HQ Panel; Defined new category 'Building Permit'  to group permit / construction related elements.

