### PR TITLE
[QoL / UI] Swiss Upgrade and Boost: Safety Lock

### DIFF
--- a/assets/Script/Languages/en.ts
+++ b/assets/Script/Languages/en.ts
@@ -1575,4 +1575,7 @@ export const EN = {
     PlayerTradeFillBy: "Fill By",
     PlayerTradeCancelled: "Cancelled",
     FormatTimeAgo: "%{time} ago",
+    SafteyLock: "Safety Lock",
+    SafteyLockTip: "When enabled, locks the upgrade button to prevent miss-clicks.",
+    SafetyLockToast: "Safety lock is On. Turn off safety lock, located near the top of the UI Panel, to purchase this upgrade.",
 };

--- a/assets/Script/Languages/en.ts
+++ b/assets/Script/Languages/en.ts
@@ -1577,5 +1577,5 @@ export const EN = {
     FormatTimeAgo: "%{time} ago",
     SafteyLock: "Safety Lock",
     SafteyLockTip: "When enabled, locks the upgrade button to prevent miss-clicks.",
-    SafetyLockToast: "Safety lock is On. Turn off safety lock, located near the top of the UI Panel, to purchase this upgrade.",
+    SafetyLockToast: "Safety lock is on, attempted action blocked.",
 };

--- a/assets/Script/UI/SwissBoostPage.ts
+++ b/assets/Script/UI/SwissBoostPage.ts
@@ -1,13 +1,16 @@
-import { D, G } from "../General/GameData";
-import { formatPercent, nf } from "../General/Helper";
+import { D, DLC, G, hasDLC } from "../General/GameData";
+import { formatPercent, ifTrue, nf } from "../General/Helper";
 import { t } from "../General/i18n";
 import {
     leftOrRight,
     uiHeaderActionBack,
+    uiBoxToggleContent,
     uiSwissBoostBoxContent,
     uiSwissBoostToggleBox,
     uiSwissMoneyBlock,
 } from "./UIHelper";
+
+let isSafetyLocked: boolean = true;
 
 export function SwissBoostPage(): m.Comp {
     return {
@@ -15,7 +18,21 @@ export function SwissBoostPage(): m.Comp {
             return m(".modal", { class: leftOrRight() }, [
                 uiHeaderActionBack(t("SwissBoost"), () => G.world.routeTo(G.swissShop.grid)),
                 m("div.scrollable", [
-                    m(".box", [uiSwissMoneyBlock(), m(".hr"), m(".banner.blue.text-m", t("SwissBoostDesc"))]),
+                    m(".box", [
+                        uiSwissMoneyBlock(), 
+                        m(".hr.dashed"),
+                        uiBoxToggleContent(
+                            m(".uppercase.text-s.text-desc.cursor-help", {title: t("SafteyLockTip")}, t("SafteyLock")),
+                            isSafetyLocked,
+                            () => {
+                                isSafetyLocked = !isSafetyLocked;
+                            },
+                            { style: { margin: "-10px 0" } },
+                            24
+                        ),
+                        m(".hr"), 
+                        m(".banner.blue.text-m", t("SwissBoostDesc")),   
+                    ]),
                     uiSwissBoostBoxContent(
                         t("ProductionMultiplier"),
                         t("ProductionMultiplierDesc"),
@@ -25,7 +42,8 @@ export function SwissBoostPage(): m.Comp {
                         1.5,
                         1,
                         100 / D.persisted.swissBoostCostDivider,
-                        100
+                        100,
+                        isSafetyLocked
                     ),
                     uiSwissBoostBoxContent(
                         t("AutoSellCapacityMultiplierV2"),
@@ -36,7 +54,8 @@ export function SwissBoostPage(): m.Comp {
                         1.5,
                         1,
                         100 / D.persisted.swissBoostCostDivider,
-                        25
+                        25,
+                        isSafetyLocked
                     ),
                     uiSwissBoostBoxContent(
                         t("BuildingUpgradeCostDivider"),
@@ -47,7 +66,8 @@ export function SwissBoostPage(): m.Comp {
                         1.5,
                         1,
                         100 / D.persisted.swissBoostCostDivider,
-                        100
+                        100,
+                        isSafetyLocked
                     ),
                     uiSwissBoostBoxContent(
                         t("BuildingPermitCostDivider"),
@@ -58,7 +78,8 @@ export function SwissBoostPage(): m.Comp {
                         1.5,
                         1,
                         50 / D.persisted.swissBoostCostDivider,
-                        100
+                        100,
+                        isSafetyLocked
                     ),
                     uiSwissBoostBoxContent(
                         t("ExtraBuildingPermit"),
@@ -69,7 +90,8 @@ export function SwissBoostPage(): m.Comp {
                         1.5,
                         1,
                         50 / D.persisted.swissBoostCostDivider,
-                        100
+                        100,
+                        isSafetyLocked
                     ),
                     uiSwissBoostBoxContent(
                         t("ExtraTradeQuota"),
@@ -80,7 +102,8 @@ export function SwissBoostPage(): m.Comp {
                         1.5,
                         1,
                         50 / D.persisted.swissBoostCostDivider,
-                        9
+                        9,
+                        isSafetyLocked
                     ),
                     uiSwissBoostBoxContent(
                         t("IndustryZoneMultiplierSwissBoost"),
@@ -91,28 +114,35 @@ export function SwissBoostPage(): m.Comp {
                         1.5,
                         0.5,
                         50 / D.persisted.swissBoostCostDivider,
-                        100
+                        100,
+                        isSafetyLocked
                     ),
                     uiSwissBoostToggleBox(
                         t("WholesaleCenterOrderFasterV2"),
                         t("WholesaleCenterOrderFasterDesc"),
                         100,
-                        "wholesaleUpgrade1"
+                        "wholesaleUpgrade1",
+                        isSafetyLocked
+
                     ),
                     uiSwissBoostToggleBox(
                         t("OfflineResearchSwissBoost"),
                         t("OfflineResearchSwissBoostDesc"),
                         100,
-                        "offlineResearch"
+                        "offlineResearch",
+                        isSafetyLocked
                     ),
                     uiSwissBoostToggleBox(
                         t("ResourceExplorerAll"),
                         t("ResourceExplorerAllDesc"),
                         100,
-                        "resourceExplorerAllDeposits"
+                        "resourceExplorerAllDeposits",
+                        isSafetyLocked
                     ),
-                    uiSwissBoostToggleBox(t("ProduceAllCrops"), t("ProduceAllCropsDesc"), 100, "produceAllCrops"),
-                    uiSwissBoostToggleBox(t("ResearchAgreement"), t("ResearchAgreementDesc"), 100, "researchAgreement"),
+                    ifTrue(hasDLC(DLC[2]), () => [
+                        uiSwissBoostToggleBox(t("ProduceAllCrops"), t("ProduceAllCropsDesc"), 100, "produceAllCrops", isSafetyLocked),
+                    ]),
+                    uiSwissBoostToggleBox(t("ResearchAgreement"), t("ResearchAgreementDesc"), 100, "researchAgreement", isSafetyLocked),
                 ]),
             ]);
         },

--- a/assets/Script/UI/SwissUpgradePage.ts
+++ b/assets/Script/UI/SwissUpgradePage.ts
@@ -1,7 +1,15 @@
 import { D, G } from "../General/GameData";
-import { formatPercent, nf } from "../General/Helper";
+import { formatPercent, ifTrue, nf } from "../General/Helper";
 import { t } from "../General/i18n";
-import { leftOrRight, uiHeaderActionBack, uiSwissMoneyBlock, uiSwissUpgradeBoxContent } from "./UIHelper";
+import { 
+    leftOrRight, 
+    uiBoxToggleContent, 
+    uiHeaderActionBack, 
+    uiSwissMoneyBlock, 
+    uiSwissUpgradeBoxContent 
+} from "./UIHelper";
+
+let isSafetyLocked: boolean = true;
 
 export function SwissUpgradePage(): m.Comp {
     return {
@@ -9,7 +17,21 @@ export function SwissUpgradePage(): m.Comp {
             return m(".modal", { class: leftOrRight() }, [
                 uiHeaderActionBack(t("SwissUpgrade"), () => G.world.routeTo(G.swissShop.grid)),
                 m("div.scrollable", [
-                    m(".box", [uiSwissMoneyBlock(), m(".hr"), m(".banner.blue.text-m", t("SwissUpgradeDesc"))]),
+                    m(".box", [
+                        uiSwissMoneyBlock(), 
+                        m(".hr.dashed"),
+                        uiBoxToggleContent(
+                            m(".uppercase.text-s.text-desc.cursor-help", {title: t("SafteyLockTip")}, t("SafteyLock")),
+                            isSafetyLocked,
+                            () => {
+                                isSafetyLocked = !isSafetyLocked;
+                            },
+                            { style: { margin: "-10px 0" } },
+                            24
+                        ),
+                        m(".hr"), 
+                        m(".banner.blue.text-m", t("SwissUpgradeDesc")),   
+                    ]),
                     uiSwissUpgradeBoxContent(
                         t("MaxBuilders"),
                         t("MaxBuildersDesc"),
@@ -19,7 +41,8 @@ export function SwissUpgradePage(): m.Comp {
                         1.75,
                         1,
                         25,
-                        10
+                        10,
+                        isSafetyLocked 
                     ),
                     uiSwissUpgradeBoxContent(
                         t("BuilderMoveSpeed"),
@@ -30,7 +53,8 @@ export function SwissUpgradePage(): m.Comp {
                         2,
                         10,
                         25,
-                        100
+                        100,
+                        isSafetyLocked
                     ),
                     uiSwissUpgradeBoxContent(
                         t("OfflineEarningTime"),
@@ -43,7 +67,8 @@ export function SwissUpgradePage(): m.Comp {
                         1.5,
                         30,
                         50,
-                        24 * 60
+                        24 * 60,
+                        isSafetyLocked
                     ),
                     uiSwissUpgradeBoxContent(
                         t("ProductionMultiplier"),
@@ -54,7 +79,8 @@ export function SwissUpgradePage(): m.Comp {
                         1.75,
                         1,
                         100,
-                        100
+                        100,
+                        isSafetyLocked
                     ),
                     uiSwissUpgradeBoxContent(
                         t("AutoSellCapacityMultiplierV2"),
@@ -65,7 +91,8 @@ export function SwissUpgradePage(): m.Comp {
                         1.75,
                         1,
                         100,
-                        25
+                        25,
+                        isSafetyLocked
                     ),
                     uiSwissUpgradeBoxContent(
                         t("BuildingUpgradeCostDivider"),
@@ -76,7 +103,8 @@ export function SwissUpgradePage(): m.Comp {
                         1.75,
                         1,
                         100,
-                        100
+                        100,
+                        isSafetyLocked
                     ),
                     uiSwissUpgradeBoxContent(
                         t("BuildingPermitCostDivider"),
@@ -87,7 +115,8 @@ export function SwissUpgradePage(): m.Comp {
                         1.75,
                         1,
                         50,
-                        100
+                        100,
+                        isSafetyLocked
                     ),
                     uiSwissUpgradeBoxContent(
                         t("ExtraBuildingPermit"),
@@ -98,7 +127,8 @@ export function SwissUpgradePage(): m.Comp {
                         1.75,
                         1,
                         50,
-                        100
+                        100,
+                        isSafetyLocked
                     ),
                     uiSwissUpgradeBoxContent(
                         t("ExtraTradeQuota"),
@@ -109,7 +139,8 @@ export function SwissUpgradePage(): m.Comp {
                         1.75,
                         1,
                         100,
-                        10
+                        10,
+                        isSafetyLocked
                     ),
                     uiSwissUpgradeBoxContent(
                         t("FuelCostDiscount"),
@@ -120,7 +151,8 @@ export function SwissUpgradePage(): m.Comp {
                         1.75,
                         5,
                         50,
-                        50
+                        50,
+                        isSafetyLocked
                     ),
                     uiSwissUpgradeBoxContent(
                         t("ExtraAdjacentBonus"),
@@ -131,7 +163,8 @@ export function SwissUpgradePage(): m.Comp {
                         1.75,
                         5,
                         50,
-                        50
+                        50,
+                        isSafetyLocked
                     ),
                     uiSwissUpgradeBoxContent(
                         t("SellRefundPercentage"),
@@ -142,7 +175,8 @@ export function SwissUpgradePage(): m.Comp {
                         1.75,
                         5,
                         50,
-                        90
+                        90,
+                        isSafetyLocked
                     ),
                     uiSwissUpgradeBoxContent(
                         t("IndustryZoneMultiplierSwissBoost"),
@@ -153,7 +187,8 @@ export function SwissUpgradePage(): m.Comp {
                         1.5,
                         0.5,
                         50,
-                        100
+                        100,
+                        isSafetyLocked
                     ),
                     uiSwissUpgradeBoxContent(
                         t("SwissBoostCostDivider"),
@@ -164,7 +199,8 @@ export function SwissUpgradePage(): m.Comp {
                         2,
                         1,
                         500,
-                        10
+                        10,
+                        isSafetyLocked
                     ),
                 ]),
             ]);

--- a/assets/Script/UI/UIHelper.ts
+++ b/assets/Script/UI/UIHelper.ts
@@ -483,13 +483,26 @@ export function uiSwissUpgradeBoxContent(
     growthBase: number,
     step: number,
     startCost: number,
-    maxValue: number
+    maxValue: number,
+    isLocked: boolean
 ): m.Children {
     const getCost = () => swissUpgradeCost(key, growthBase, step, startCost);
     const cost = getCost();
-    let button = m(".row", [m("div", t("MaxUpgrade")), m(".f1")]);
-    if (D.persisted[key] < maxValue) {
-        button = m(".row", [m("div", action), m(".f1"), m("div", `${t("SwissMoney", { money: nf(cost) })}`)]);
+    let button: m.Children = m(".row", [m("div", t("MaxUpgrade")), m(".f1")]);
+    if(isLocked) {
+         button = m(".row", [
+                m("div.green", iconB("lock", 16, 5)),
+                m("div", action),
+                m(".f1"),
+                m("div", `${t("SwissMoney", { money: nf(cost) })}`),
+        ]);
+    } else if (D.persisted[key] < maxValue) {
+         button = m(".row", [
+                m("div.red", {title: t("SafetyUnlockedTip")}, iconB("lock_open", 16, 5)),
+                m("div", action),
+                m(".f1"),
+                m("div", `${t("SwissMoney", { money: nf(cost) })}`),
+        ]);
     } else {
         // @ts-expect-error
         D.persisted[key] = maxValue;
@@ -500,6 +513,11 @@ export function uiSwissUpgradeBoxContent(
         value,
         button,
         () => {
+            if(isLocked) {
+                G.audio.playClick();
+                showToast(t("SafetyLockToast"));
+                return;
+            }                
             if (D.persisted[key] >= maxValue) {
                 G.audio.playError();
                 showToast(t("MaxUpgradeDesc"));
@@ -529,13 +547,26 @@ export function uiSwissBoostBoxContent(
     growthBase: number,
     step: number,
     startCost: number,
-    maxValue: number
+    maxValue: number,
+    isLocked: boolean
 ): m.Children {
     const getCost = () => swissBoostCost(key, growthBase, step, startCost);
     const cost = getCost();
-    let button = m(".row", [m("div", t("MaxUpgrade")), m(".f1")]);
-    if (D.swissBoosts[key] < maxValue) {
-        button = m(".row", [m("div", action), m(".f1"), m("div", `${t("SwissMoney", { money: nf(cost) })}`)]);
+    let button: m.Children = m(".row", [m("div", t("MaxUpgrade")), m(".f1")]);
+    if(isLocked) {
+         button = m(".row", [
+            m("div.green", iconB("lock", 16, 5)),
+            m("div", action),
+            m(".f1"),
+            m("div", `${t("SwissMoney", { money: nf(cost) })}`),
+        ]);
+    } else if (D.swissBoosts[key] < maxValue) {
+        button = m(".row", [
+            m("div.red", {title: t("SafetyUnlockedTip")}, iconB("lock_open", 16, 5)),
+            m("div", action),
+            m(".f1"),
+            m("div", `${t("SwissMoney", { money: nf(cost) })}`),
+        ]);
     } else {
         D.swissBoosts[key] = maxValue;
     }
@@ -545,6 +576,11 @@ export function uiSwissBoostBoxContent(
         value,
         button,
         () => {
+            if(isLocked) {
+                G.audio.playClick();
+                showToast(t("SafetyLockToast"));
+                return;
+            }
             if (D.swissBoosts[key] >= maxValue) {
                 G.audio.playError();
                 showToast(t("MaxUpgradeDesc"));
@@ -556,7 +592,7 @@ export function uiSwissBoostBoxContent(
                 showToast(t("NotEnoughSwissMoney"));
                 return;
             }
-
+            
             D.persisted.prestigeCurrency -= cost;
             D.swissBoosts[key] += step;
             G.audio.playClick();
@@ -569,33 +605,49 @@ export function uiSwissBoostToggleBox(
     title: m.Children,
     desc: m.Children,
     cost: number,
-    key: BooleanKeyOf<SwissBoosts>
+    key: BooleanKeyOf<SwissBoosts>,
+    isLocked: boolean
 ): m.Children {
-    return m(
-        ".box",
-        m(".two-col", [
-            m("div", [m("div", title), m(".text-desc.text-s", desc)]),
-            D.swissBoosts[key]
-                ? iconB("check_circle", 24, 0, {}, { class: "green" })
-                : m(
-                      ".pointer.nobreak.ml10",
-                      {
-                          onclick: () => {
-                              if (D.persisted.prestigeCurrency < cost) {
-                                  G.audio.playError();
-                                  showToast(t("NotEnoughSwissMoney"));
-                                  return;
-                              }
-                              G.audio.playClick();
-                              D.persisted.prestigeCurrency -= cost;
-                              D.swissBoosts[key] = true;
-                          },
-                          class: D.persisted.prestigeCurrency < cost ? "disabled" : "blue",
-                      },
-                      `${t("SwissMoney", { money: nf(cost) })}`
-                  ),
-        ])
-    );
+    if(D.swissBoosts[key]) {
+        return m(".box",
+            m(".two-col", [
+                m("div", [m("div", title), m(".text-desc.text-s", desc)]),
+                iconB("check_circle", 24, 0, {}, { class: "green" })  
+            ])
+        );
+    } else {
+        return m(
+            ".box",
+            m(".two-col", [
+                m("div", [
+                    m(".two-col", [
+                        isLocked 
+                            ? m("div", iconB("lock", 16, 0, {}, { class: "green" }))
+                            : m("div", iconB("lock_open", 16, 0, {}, { class: "red" })),
+                            m("div", {style: "text-align: left;"}, title)
+                    ]),
+                    m(".text-desc.text-s", desc),
+                ]),
+                m(
+                    ".pointer.nobreak.ml10",
+                    {
+                        onclick: () => {
+                            if (D.persisted.prestigeCurrency < cost) {
+                                G.audio.playError();
+                                showToast(t("NotEnoughSwissMoney"));
+                                return;
+                            }
+                            G.audio.playClick();
+                            D.persisted.prestigeCurrency -= cost;
+                            D.swissBoosts[key] = true;
+                        },
+                        class: D.persisted.prestigeCurrency < cost ? "disabled" : "blue",
+                    },
+                    `${t("SwissMoney", { money: nf(cost) })}`
+                ),
+            ])
+        );
+    }
 }
 
 export const InputOverrideFallbackOptions: Record<InputOverrideFallback, () => string> = {


### PR DESCRIPTION
### Overview
Adds a new session setting, 'Safety Lock',  to both the Swiss Upgrade and Swiss Boost Pages. It defaults to enabled and is designed to prevent _unintentional_ swiss spending. A small lock/unlock status icon has been added next to each 'Swiss Upgrade' and 'Swiss Boost' titles to denote the current state of the feature.

[Locked and Unlocked Sates for uiSwissUpgradeBoxContent and uiSwissBoostBoxContent [type: img] ](https://i.gyazo.com/12f85159cc5a77cc19ce81b6a74641ca.png)
[Locked and Unlocked Sates for uiSwissBoostToggleBox [type: img]](https://i.gyazo.com/adec3e92568dc77aef95fedd4af9a0dc.png)
[New Toast [type: img]](https://i.gyazo.com/24b096b10e992c09df2f3df880fe829e.png) **[Updated: 2023-01-09]**

### Changelog Overview

1.  Updated Script\Languages\en.ts; 
Added 3 new entries to support the update 

2. Script\UI\SwissUpgrade.ts; 
Added new boolean property isSafetyLocked to track the state of the UI feature. Added new session setting 'Safety Lock'.
Added a tooltip for the setting.
Updated imports.
Updated uiSwissUpgradeBoxContent calls to pass current value of isSafetyLocked 
3. Script\UI\SwissBoost.ts;
Added new boolean property isSafetyLocked to track the state of the UI feature. Added new session setting 'Safety Lock'.
Added a tooltip for the setting.
Encapsulated 'Produce All Crops' uiSwissBoostToggleBox in a conditional check for if the player has expansion 2 content.
Updated imports.
Updated uiSwissBoostBoxContent and uiSwissBoostToggleBox calls to pass current value of isSafetyLocked 
4. Script\UI\UIHelper.ts;
Modified uiSwissUpgradeBoxContent , uiSwissBoostBoxContent and uiSwissBoostToggleBox definition to expect new parameter isLocked: boolean 
Modified uiSwissUpgradeBoxContent, uiSwissBoostBoxContent and uiSwissBoostToggleBox logic slightly to output the current lock state. 

### Additional Notes:
1. Swiss Boost 'Produce All Crops' is now only visible to players with Expansion 2 Content. 