### PR TITLE
[BugFix] Mass Downgrade Calculation Logic Error

### DIFF
--- a/assets/Script/CoreGame/Logic/Logic.ts
+++ b/assets/Script/CoreGame/Logic/Logic.ts
@@ -437,7 +437,7 @@ export function getDowngradeCost(
     downgradeCostFunction: (level: number) => number
 ): number {
     let cost = 0;
-    for (let i = 0; i <= numberOfLevels; i++) {
+    for (let i = 0; i < numberOfLevels; i++) {
         cost += downgradeCostFunction(currentLevel - i);
     }
     return cost;


### PR DESCRIPTION
Implemented fix to bug created via incorrect logical comparison; the original bug report and solution was provided by BarkyAllen.