### PR TITLE
Propagate the `AbortError` up to the caller

### DIFF
--- a/assets/Script/General/NativeSdk.ts
+++ b/assets/Script/General/NativeSdk.ts
@@ -183,6 +183,8 @@ export class DefaultNativeSdk {
             await stream.write(content);
             await stream.close();
         } catch (error) {
+            if(error instanceof AbortError)
+                throw error;
             downloadFile(content, suggestedName);
         }
     }


### PR DESCRIPTION
If the dialog is closed by the player the callers will not continue as if the process succeeded. The callers have their own exception handling that although is basic does not let the program to end up in disarray, but probably needs at least a better error message shown.